### PR TITLE
Using simple-repository stack and PEP-503 simple repo definitions, instead of the non-standards based JSON API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,10 +31,20 @@ This will start up a Flask app, and will print out a line such as::
 
 You can then call pip with::
 
-   pip install --index-url http://127.0.0.1:5000/ astropy
+   pip install --index-url http://127.0.0.1:5000/simple/ astropy
 
 and this will then install the requested packages and all dependencies,
 ignoring any releases after the cutoff date specified above.
+
+How it works
+~~~~~~~~~~~~
+
+`pypi-timemachine` builds upon the simple-repository stack, and uses the
+standards based PEP-503 repository. In order to filter by time, the upstream
+repository PyPI must provide PEP-700 metadata (which PyPI does).
+The results are filtered by pypi-timemachine, and then served as HTML or JSON
+via the standard PEP-503 interface.
+
 
 Caveats/warnings
 ~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -19,19 +19,19 @@ Using
 
 Once installed, you can run a PyPI server with::
 
-   pypi-timemachine 2014-02-03
+   pypi-timemachine 2021-02-03
 
 or if you need to specify a precise time (in UTC)::
 
-   pypi-timemachine 2014-02-03T12:33:02
+   pypi-timemachine 2021-02-03T12:33:02
 
-This will start up a Flask app, and will print out a line such as::
+This will start up a webapp running uvicorn, and will print out a line such as::
 
-   Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+   Starting pypi-timemachine server at http://127.0.0.1:5000/
 
 You can then call pip with::
 
-   pip install --index-url http://127.0.0.1:5000/simple/ astropy
+   pip install --index-url http://127.0.0.1:5000/ astropy
 
 and this will then install the requested packages and all dependencies,
 ignoring any releases after the cutoff date specified above.
@@ -39,9 +39,10 @@ ignoring any releases after the cutoff date specified above.
 How it works
 ~~~~~~~~~~~~
 
-`pypi-timemachine` builds upon the simple-repository stack, and uses the
-standards based PEP-503 repository. In order to filter by time, the upstream
-repository PyPI must provide PEP-700 metadata (which PyPI does).
+`pypi-timemachine` builds upon the `simple-repository`_ stack, and uses the
+standards based PEP-503 repository definition to serve packages.
+In order to filter by time, the upstream repository must provide PEP-700
+metadata (which PyPI does).
 The results are filtered by pypi-timemachine, and then served as HTML or JSON
 via the standard PEP-503 interface.
 
@@ -56,3 +57,6 @@ already installed, no matter how recent the version, it will not be
 installed again. Therefore, I recommend using pip with the custom index
 URL inside a clean environment (but you can run the ``pypi-timemachine``
 command inside your regular environment.)
+
+
+.. _simple-repository: https://github.com/simple-repository/

--- a/pypi_timemachine/__main__.py
+++ b/pypi_timemachine/__main__.py
@@ -1,4 +1,5 @@
+from .core import main
+
 
 if __name__ == '__main__':
-    from pypi_timemachine.core import main
     main()

--- a/pypi_timemachine/core.py
+++ b/pypi_timemachine/core.py
@@ -1,35 +1,95 @@
-import socket
+from contextlib import asynccontextmanager
+import dataclasses
 from datetime import datetime
+import socket
+import sys
+import typing
 
 import click
-import requests
+import fastapi
+import httpx
+from simple_repository.components.core import RepositoryContainer, SimpleRepository
+from simple_repository.components.http import HttpRepository
+from simple_repository_server.routers import simple
+from simple_repository import model
+import uvicorn
 
-from tornado.ioloop import IOLoop
-from tornado.web import RequestHandler, Application
-from tornado.routing import PathMatches
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    override = lambda fn: fn
+
 
 MAIN_PYPI = 'https://pypi.org/simple/'
-JSON_URL = 'https://pypi.org/pypi/{package}/json'
-
-PACKAGE_HTML = """
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Links for {package}</title>
-  </head>
-  <body>
-    <h1>Links for {package}</h1>
-{links}
-  </body>
-</html>
-"""
 
 
-def parse_iso(dt):
+def parse_iso(dt) -> datetime:
     try:
         return datetime.strptime(dt, '%Y-%m-%d')
     except:
         return datetime.strptime(dt, '%Y-%m-%dT%H:%M:%S')
+
+
+def create_app(repo: SimpleRepository) -> fastapi.FastAPI:
+    @asynccontextmanager
+    async def lifespan(app: fastapi.FastAPI) -> typing.AsyncIterator[None]:
+        async with httpx.AsyncClient() as http_client:
+            app.include_router(simple.build_router(repo, http_client), prefix="")
+            yield
+
+    app = fastapi.FastAPI(
+        openapi_url=None,  # Disables automatic OpenAPI documentation (Swagger & Redoc)
+        lifespan=lifespan,
+    )
+    return app
+
+
+class DateFilteredReleases(RepositoryContainer):
+    """
+    A component used to remove released projects from the source
+    repository if they were released after the configured date.
+
+    This component can be used only if the source repository exposes the upload
+    date according to PEP-700: https://peps.python.org/pep-0700/.
+
+    """
+    def __init__(
+        self,
+        source: SimpleRepository,
+        cutoff_date: datetime,
+    ) -> None:
+        self._cutoff_date = cutoff_date
+        super().__init__(source)
+
+    @override
+    async def get_project_page(
+        self,
+        project_name: str,
+        *,
+        request_context: model.RequestContext = model.RequestContext.DEFAULT,
+    ) -> model.ProjectDetail:
+        project_page = await super().get_project_page(
+            project_name,
+            request_context=request_context,
+        )
+
+        return self._exclude_recent_distributions(
+            project_page=project_page,
+            now=datetime.now(),
+        )
+
+    def _exclude_recent_distributions(
+        self,
+        project_page: model.ProjectDetail,
+        now: datetime,
+    ) -> model.ProjectDetail:
+        filtered_files = tuple(
+            file for file in project_page.files
+            if not file.upload_time or
+            (file.upload_time <= self._cutoff_date)
+        )
+        return dataclasses.replace(project_page, files=filtered_files)
 
 
 @click.command()
@@ -40,30 +100,12 @@ def main(cutoff_date, port, quiet):
 
     CUTOFF = parse_iso(cutoff_date)
 
-    INDEX = requests.get(MAIN_PYPI).content
+    repo = DateFilteredReleases(
+        HttpRepository(MAIN_PYPI),
+        cutoff_date=CUTOFF,
+    )
 
-    class MainIndexHandler(RequestHandler):
-
-        async def get(self):
-            return self.write(INDEX)
-
-    class PackageIndexHandler(RequestHandler):
-
-        async def get(self, package):
-
-            package_index = requests.get(JSON_URL.format(package=package)).json()
-            release_links = ""
-            for release in package_index['releases'].values():
-                for file in release:
-                    release_date = parse_iso(file['upload_time'])
-                    if release_date < CUTOFF:
-                        if file['requires_python'] is None:
-                            release_links += '    <a href="{url}#sha256={sha256}">{filename}</a><br/>\n'.format(url=file['url'], sha256=file['digests']['sha256'], filename=file['filename'])
-                        else:
-                            rp = file['requires_python'].replace('>', '&gt;')
-                            release_links += '    <a href="{url}#sha256={sha256}" data-requires-python="{rp}">{filename}</a><br/>\n'.format(url=file['url'], sha256=file['digests']['sha256'], rp=rp, filename=file['filename'])
-
-            self.write(PACKAGE_HTML.format(package=package, links=release_links))
+    app = create_app(repo)
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(('localhost', 0))
@@ -71,12 +113,7 @@ def main(cutoff_date, port, quiet):
         port = sock.getsockname()[1]
     sock.close()
 
-    app = Application([(r"/", MainIndexHandler),
-                       (PathMatches(r"/(?P<package>\S+)\//?"), PackageIndexHandler)])
-
-    app.listen(port=port)
-
     if not quiet:
         print(f'Starting pypi-timemachine server at http://localhost:{port}')
 
-    IOLoop.instance().start()
+    uvicorn.run(app=app, port=int(port))

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,8 @@ install_requires =
     fastapi
     httpx
     importlib-metadata; python_version < "3.8"
-    simple-repository
-    simple-repository-server
+    simple-repository>=0.8.2
+    simple-repository-server>=0.8.1
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,11 @@ packages = find:
 setup_requires = setuptools_scm
 install_requires =
     click
+    fastapi
+    httpx
     importlib-metadata; python_version < "3.8"
-    requests
-    tornado
+    simple-repository
+    simple-repository-server
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
:wave: @astrofrog (long time no see... hope you're doing well!)

I have been working on providing package repository infrastructure at work, and have built up a set of libraries that make building custom repositories child's play :stuck_out_tongue_winking_eye:. In fact, I thought I would test it out on your awesome `pypi-timemachine`, and include my <30min hack in this PR. The result is a fully functional prototype ~(though I was disappointed with the fact that implementing #7 wasn't so easy due to some inflexibility in the `simple-repository-server` router definition - I will refine that :wink:)~

A huge advantage of the approach taken in this PR is that you no longer rely on the (original and non-standardised) JSON API, and instead are using the PEP-503++ goodness that is out there on PyPI already.

~I doubt you actually want to merge this (just yet at least) - the `simple-repository` codebase is still in preview / not-yet-maintained stage, and I would be fine if you want to go ahead and close the PR without merge.~


This PR closes #7 (though I didn't document it too much, and I didn't make the date argument optional in the CLI, so some follow-up work is needed). It will be very easy to support custom index urls (#8), though maybe some care will be needed to raise an error if the upstream repository doesn't actually give you PEP-700 metadata (i.e. the release date). It also closes #9. 