### PR TITLE
Use `importlib.metadata` instead of `pkg_resources` to get the package version.

### DIFF
--- a/pypi_timemachine/__init__.py
+++ b/pypi_timemachine/__init__.py
@@ -1,6 +1,11 @@
-from pkg_resources import get_distribution, DistributionNotFound
+import sys
+
+if sys.version_info < (3, 8):
+    from importlib_metadata import PackageNotFoundError, version
+else:
+    from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ packages = find:
 setup_requires = setuptools_scm
 install_requires =
     click
+    importlib-metadata; python_version < "3.8"
     requests
     tornado
 


### PR DESCRIPTION
This module was added to the Python in 3.8 (see [docs](https://docs.python.org/3/library/importlib.metadata.html#distribution-versions)),
but a backport is available in the form of [`importlib-metadata`](https://pypi.org/project/importlib-metadata).

This avoids errors like

```console
$ uvx pypi-timemachine 2018-06-07
Traceback (most recent call last):
  File "/Users/erm/.cache/uv/archive-v0/FaS80efedkv1ufbNxv18X/bin/pypi-timemachine", line 6, in <module>
    from pypi_timemachine.core import main
  File "/Users/erm/.cache/uv/archive-v0/FaS80efedkv1ufbNxv18X/lib/python3.13/site-packages/pypi_timemachine/__init__.py", line 1, in <module>
    from pkg_resources import get_distribution, DistributionNotFound
ModuleNotFoundError: No module named 'pkg_resources'
```

which FWIW has a simple workaround

```shell
uvx --with setuptools pypi-timemachine 2018-06-07
```
