### PR TITLE
Allow custom index to be passed at startup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,16 @@ You can then call pip with::
 and this will then install the requested packages and all dependencies,
 ignoring any releases after the cutoff date specified above.
 
+For convenience, it is also possible to specify the cutoff date as part of the
+repository URL, using the pattern `http://{host}/snapshot/{cutoff_date}/`.
+Cutoff date can be either an RFC 3339 timestamp (e.g. `2006-12-02T02:07:43Z`)
+or a simple date (e.g., 2006-12-02). For example::
+
+   pip install --index-url http://127.0.0.1:5000/snapshot/2024-12-03 astropy
+
+Would install the requested packages and all dependencies from the date given in
+the index URL.
+
 It is possible to run the time machine against a custom Python package
 repository, provided it includes date metadata as defined in PEP-700,
 specifically the `upload-time` field::

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,12 @@ You can then call pip with::
 and this will then install the requested packages and all dependencies,
 ignoring any releases after the cutoff date specified above.
 
+It is possible to run the time machine against a custom Python package
+repository, provided it includes date metadata as defined in PEP-700,
+specifically the `upload-time` field::
+
+  pypi-timemachine 2021-02-03 --index-url https://my-custom-repo/simple/
+
 How it works
 ~~~~~~~~~~~~
 

--- a/pypi_timemachine/core.py
+++ b/pypi_timemachine/core.py
@@ -125,11 +125,12 @@ class DateFilteredReleases(RepositoryContainer):
 @click.argument('cutoff_date')
 @click.option('--port', default=None)
 @click.option('--quiet', default=False, is_flag=True)
-def main(cutoff_date, port, quiet):
+@click.option('--index-url', default=MAIN_PYPI)
+def main(cutoff_date: str | None, port: str | None, quiet: bool, index_url: str):
 
     CUTOFF = parse_iso(cutoff_date)
 
-    repo = HttpRepository(MAIN_PYPI)
+    repo = HttpRepository(index_url)
 
     # TODO: Currently all resources get streamed through our server, so an installation of a big wheel
     #  results in a lot of traffic passing through the timemachine server. The issue for this

--- a/pypi_timemachine/tests/test_basic.py
+++ b/pypi_timemachine/tests/test_basic.py
@@ -3,12 +3,12 @@ import sys
 import time
 import contextlib
 import subprocess
-
+import typing
 
 @contextlib.contextmanager
-def timemachine(date, port=8100):
+def timemachine(date: str, port: int = 8100, extra_args: typing.Iterable[str] = ()):
 
-    process = subprocess.Popen(["pypi-timemachine", date, "--port", str(port)])
+    process = subprocess.Popen(["pypi-timemachine", date, "--port", str(port)] + list(extra_args))
 
     try:
         time.sleep(2)
@@ -17,7 +17,7 @@ def timemachine(date, port=8100):
         process.terminate()
         process.wait()
 
-
+BASIC_DATE = "2024-12-03T22:12:33Z"
 BASIC_EXPECTED = """
 astropy==7.0.0
 astropy-iers-data==0.2024.12.2.0.35.34
@@ -35,7 +35,7 @@ def test_basic(tmpdir):
         "Scripts" if os.name == "nt" else "bin",
         "python",
     )
-    with timemachine("2024-12-03T22:12:33"):
+    with timemachine(BASIC_DATE):
         subprocess.check_output(
             [
                 python_executable,
@@ -47,5 +47,29 @@ def test_basic(tmpdir):
                 "astropy",
             ]
         )
+    freeze_output = subprocess.check_output([python_executable, "-m", "pip", "freeze"])
+    assert freeze_output.decode("utf-8").strip().splitlines() == BASIC_EXPECTED.strip().splitlines()
+
+
+def test_custom_index_url(tmpdir):
+    subprocess.check_output([sys.executable, "-m", "venv", tmpdir])
+    python_executable = os.path.join(
+        tmpdir,
+        "Scripts" if os.name == "nt" else "bin",
+        "python",
+    )
+    with timemachine("2900-01-01"):
+        with timemachine("2900-01-01", port=8101, extra_args=['--index-url', f"http://localhost:8100/snapshot/{BASIC_DATE}"]):
+            subprocess.check_output(
+                [
+                    python_executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "-i",
+                    f"http://localhost:8101",
+                    "astropy",
+                ]
+            )
     freeze_output = subprocess.check_output([python_executable, "-m", "pip", "freeze"])
     assert freeze_output.decode("utf-8").strip().splitlines() == BASIC_EXPECTED.strip().splitlines()


### PR DESCRIPTION
It also clarifies the behaviour of passing `cutoff` as part of the URL segment (as requested in https://github.com/astrofrog/pypi-timemachine/issues/7).

Note: I do not know what it looks like if you try to do this against a repository which doesn't have the right metadata (`upload-time`) - this is going to be fairly common, as even `devpi` doesn't have such support yet (e.g. https://github.com/devpi/devpi/pull/1023#issuecomment-2792268078). Given https://github.com/astrofrog/pypi-timemachine/blob/master/pypi_timemachine/core.py#L118, I'm guessing that we will drop everything and you will get an error saying that there were no suitable distributions found.

Closes #8