### PR TITLE
Specify the minimum Python version as Python 3.11

### DIFF
--- a/pypi_timemachine/__init__.py
+++ b/pypi_timemachine/__init__.py
@@ -1,9 +1,4 @@
-import sys
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import PackageNotFoundError, version
-else:
-    from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ authors = [
   { name = "Thomas Robitaille", email = "thomas.robitaille@gmail.com" },
 ]
 
+requires-python = ">=3.11"
 dependencies = [
   "click",
   "fastapi",
   "httpx",
-  "importlib-metadata; python_version < '3.8'",
   "simple-repository>=0.8.2",
   "simple-repository-server>=0.8.1",
 ]


### PR DESCRIPTION
Specify the minimum Python version as Python 3.11 (a constraint from simple-repository-server)

Closes #17 